### PR TITLE
feat: add `ecs` & `phpstan` code analysis

### DIFF
--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -1,0 +1,40 @@
+name: Code Analysis
+
+on:
+  pull_request: null
+  push:
+    branches:
+      - v3-dev
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  code_analysis:
+    strategy:
+      fail-fast: false
+      matrix:
+        actions:
+          - name: 'PHPStan'
+            run: composer phpstan
+          - name: 'Coding Standards'
+            run: composer fix-cs
+    name: ${{ matrix.actions.name }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: /tmp/composer-cache
+          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+      - name: Setup PHP
+        id: setup-php
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          extensions: 'ctype,curl,dom,iconv,imagick,intl,json,mbstring,openssl,pcre,pdo,reflection,spl,zip'
+          ini-values: post_max_size=256M, max_execution_time=180, memory_limit=512M
+          tools: composer:v2
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --no-ansi --no-progress
+      - run: ${{ matrix.actions.run }}

--- a/composer.json
+++ b/composer.json
@@ -1,41 +1,59 @@
 {
-    "name": "doublesecretagency/craft-cpcss",
-    "description": "Add custom CSS to your Control Panel.",
-    "type": "craft-plugin",
-    "version": "3.0.0",
-    "keywords": [
-        "craft",
-        "cms",
-        "craftcms",
-        "craft-plugin",
-        "cp-css",
-        "css"
-    ],
-    "support": {
-        "docs": "https://github.com/doublesecretagency/craft-cpcss/blob/v3/README.md",
-        "issues": "https://github.com/doublesecretagency/craft-cpcss/issues"
-    },
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Double Secret Agency",
-            "homepage": "https://www.doublesecretagency.com/plugins"
-        }
-    ],
-    "require": {
-        "craftcms/cms": "^5.0.0-beta",
-        "nystudio107/craft-code-editor": "^1.0.7"
-    },
-    "autoload": {
-        "psr-4": {
-          "doublesecretagency\\cpcss\\": "src/"
-        }
-    },
-    "extra": {
-        "name": "Control Panel CSS",
-        "handle": "cp-css",
-        "schemaVersion": "2.0.0",
-        "changelogUrl": "https://raw.githubusercontent.com/doublesecretagency/craft-cpcss/v3/CHANGELOG.md",
-        "class": "doublesecretagency\\cpcss\\CpCss"
+  "name": "doublesecretagency/craft-cpcss",
+  "description": "Add custom CSS to your Control Panel.",
+  "type": "craft-plugin",
+  "version": "3.0.0",
+  "keywords": [
+    "craft",
+    "cms",
+    "craftcms",
+    "craft-plugin",
+    "cp-css",
+    "css"
+  ],
+  "support": {
+    "docs": "https://github.com/doublesecretagency/craft-cpcss/blob/v3/README.md",
+    "issues": "https://github.com/doublesecretagency/craft-cpcss/issues"
+  },
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Double Secret Agency",
+      "homepage": "https://www.doublesecretagency.com/plugins"
     }
+  ],
+  "require": {
+    "craftcms/cms": "^5.0.0-beta",
+    "nystudio107/craft-code-editor": "^1.0.7"
+  },
+  "autoload": {
+    "psr-4": {
+      "doublesecretagency\\cpcss\\": "src/"
+    }
+  },
+  "extra": {
+    "name": "Control Panel CSS",
+    "handle": "cp-css",
+    "schemaVersion": "2.0.0",
+    "changelogUrl": "https://raw.githubusercontent.com/doublesecretagency/craft-cpcss/v3/CHANGELOG.md",
+    "class": "doublesecretagency\\cpcss\\CpCss"
+  },
+  "require-dev": {
+    "craftcms/ecs": "dev-main",
+    "craftcms/phpstan": "dev-main",
+    "craftcms/rector": "dev-main"
+  },
+  "scripts": {
+    "phpstan": "phpstan --ansi --memory-limit=1G",
+    "check-cs": "ecs check --ansi",
+    "fix-cs": "ecs check --fix --ansi"
+  },
+  "config": {
+    "allow-plugins": {
+      "craftcms/plugin-installer": true,
+      "yiisoft/yii2-composer": true
+    },
+    "optimize-autoloader": true,
+    "sort-packages": true
+  }
 }

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,13 @@
+<?php
+
+use craft\ecs\SetList;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+
+return static function(ECSConfig $ecsConfig): void {
+    $ecsConfig->paths([
+        __DIR__ . '/src',
+        __FILE__,
+    ]);
+    $ecsConfig->parallel();
+    $ecsConfig->sets([SetList::CRAFT_CMS_4]);
+};

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+includes:
+    - %currentWorkingDirectory%/vendor/craftcms/phpstan/phpstan.neon
+
+parameters:
+    level: 5
+    paths:
+        - src

--- a/src/CpCss.php
+++ b/src/CpCss.php
@@ -26,7 +26,6 @@ use yii\base\Event;
  */
 class CpCss extends Plugin
 {
-
     /**
      * @var CpCss Self-referential plugin property.
      */
@@ -54,7 +53,7 @@ class CpCss extends Plugin
         Event::on(
             View::class,
             View::EVENT_BEFORE_RENDER_PAGE_TEMPLATE,
-            function (TemplateEvent $event) {
+            function(TemplateEvent $event) {
 
                 // Get view
                 $view = Craft::$app->getView();
@@ -69,7 +68,6 @@ class CpCss extends Plugin
                 if ($css) {
                     $view->registerCss($css);
                 }
-
             }
         );
     }
@@ -96,5 +94,4 @@ class CpCss extends Plugin
             'docsUrl' => $this->documentationUrl,
         ]);
     }
-
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -19,7 +19,6 @@ use craft\base\Model;
  */
 class Settings extends Model
 {
-
     /**
      * @var string Path for the CSS file to load in the control panel.
      */
@@ -34,5 +33,4 @@ class Settings extends Model
      * @var bool Whether to enable the hash-based cache busting.
      */
     public bool $cacheBusting = true;
-
 }

--- a/src/web/assets/CustomAssets.php
+++ b/src/web/assets/CustomAssets.php
@@ -24,7 +24,6 @@ use doublesecretagency\cpcss\models\Settings;
  */
 class CustomAssets extends AssetBundle
 {
-
     /**
      * @inheritdoc
      */
@@ -69,7 +68,6 @@ class CustomAssets extends AssetBundle
                 // Reference file without a hash
                 $this->css[] = $file;
             }
-
         }
     }
 
@@ -106,5 +104,4 @@ class CustomAssets extends AssetBundle
         // Return file with hash
         return "{$file}?e={$hash}";
     }
-
 }

--- a/src/web/assets/CustomAssets.php
+++ b/src/web/assets/CustomAssets.php
@@ -93,14 +93,6 @@ class CustomAssets extends AssetBundle
         // Get hash of contents
         $hash = @sha1($contents);
 
-        // If unable to hash file contents
-        if (!$hash) {
-            // Log warning
-            Craft::warning("Can't bust cache for CP CSS, unable to hash contents of $file");
-            // Return file without hash
-            return $file;
-        }
-
         // Return file with hash
         return "{$file}?e={$hash}";
     }


### PR DESCRIPTION
Add `ecs` & `phpstan` code analysis

I also ran both `ecs` and `phpstan`, which cleaned up the code, and I manually fixed one error `phpstan` pointed out.

You can manually run either `ecs` or `phpstan` in local dev, and they will also automatically be run:

* Whenever you push to the `v3-dev` branch
* Whenever someone else does a PR

When someone does a PR, it'll look like this for them:

<img width="930" alt="Screenshot 2024-03-11 at 10 30 55 PM" src="https://github.com/doublesecretagency/craft-cpcss/assets/7570798/13964605-549d-4073-9511-3143c0432012">

...and then once it has passed (or failed) it'll look like this:

<img width="930" alt="Screenshot 2024-03-11 at 10 31 25 PM" src="https://github.com/doublesecretagency/craft-cpcss/assets/7570798/9d6b2e57-85b8-460f-9eb5-7086f78a1acd">
